### PR TITLE
Refactor HasMedia to sync rather than attach by default

### DIFF
--- a/src/HasMedia.php
+++ b/src/HasMedia.php
@@ -105,7 +105,6 @@ trait HasMedia
         }
 
         \DB::transaction(function () use ($media, $group, $conversions, $detachExisting) {
-
             $this->registerMediaGroups();
             $mediaGroup = $this->getMediaGroup($group);
 

--- a/src/HasMedia.php
+++ b/src/HasMedia.php
@@ -22,14 +22,13 @@ trait HasMedia
     public function media()
     {
         return $this->morphToMany(config('media.model'), 'mediable')
-            ->withPivot('group');
+                    ->withPivot('group');
     }
 
     /**
      * Determine if there is any media in the specified group.
      *
-     * @param string $group
-     *
+     * @param  string  $group
      * @return mixed
      */
     public function hasMedia(string $group = 'default')
@@ -40,8 +39,7 @@ trait HasMedia
     /**
      * Get all the media in the specified group.
      *
-     * @param string $group
-     *
+     * @param  string  $group
      * @return mixed
      */
     public function getMedia(string $group = 'default')
@@ -52,8 +50,7 @@ trait HasMedia
     /**
      * Get the first media item in the specified group.
      *
-     * @param string $group
-     *
+     * @param string  $group
      * @return mixed
      */
     public function getFirstMedia(string $group = 'default')
@@ -64,14 +61,13 @@ trait HasMedia
     /**
      * Get the url of the first media item in the specified group.
      *
-     * @param string $group
-     * @param string $conversion
-     *
+     * @param  string  $group
+     * @param  string  $conversion
      * @return string
      */
     public function getFirstMediaUrl(string $group = 'default', string $conversion = '')
     {
-        if (!$media = $this->getFirstMedia($group)) {
+        if (! $media = $this->getFirstMedia($group)) {
             return '';
         }
 
@@ -81,10 +77,9 @@ trait HasMedia
     /**
      * Attach media to the specified group.
      *
-     * @param mixed  $media
-     * @param string $group
-     * @param array  $conversions
-     *
+     * @param  mixed  $media
+     * @param  string  $group
+     * @param  array  $conversions
      * @return void
      */
     public function attachMedia($media, string $group = 'default', array $conversions = [])
@@ -95,7 +90,7 @@ trait HasMedia
     /**
      * Syncronise media against the specified group
      *
-     * @param mixed  $media
+     * @param mixed $media
      * @param string $group
      * @param array  $conversions
      * @param bool   $detachExisting
@@ -140,8 +135,7 @@ trait HasMedia
     /**
      * Parse the media id's from the mixed input.
      *
-     * @param mixed $media
-     *
+     * @param  mixed  $media
      * @return array
      */
     protected function parseMediaIds($media)
@@ -154,7 +148,7 @@ trait HasMedia
             return [$media->getKey()];
         }
 
-        return (array)$media;
+        return (array) $media;
     }
 
     /**
@@ -170,8 +164,7 @@ trait HasMedia
     /**
      * Register a new media group.
      *
-     * @param string $name
-     *
+     * @param  string  $name
      * @return MediaGroup
      */
     protected function addMediaGroup(string $name)
@@ -186,8 +179,7 @@ trait HasMedia
     /**
      * Get the media group with the specified name.
      *
-     * @param string $name
-     *
+     * @param  string  $name
      * @return MediaGroup|null
      */
     public function getMediaGroup(string $name)
@@ -198,8 +190,7 @@ trait HasMedia
     /**
      * Detach the specified media.
      *
-     * @param null $media
-     *
+     * @param  null  $media
      * @return void
      */
     public function detachMedia($media = null)
@@ -210,8 +201,7 @@ trait HasMedia
     /**
      * Detach all the media in the specified group.
      *
-     * @param string $group
-     *
+     * @param  string  $group
      * @return void
      */
     public function clearMediaGroup(string $group = 'default')

--- a/src/HasMedia.php
+++ b/src/HasMedia.php
@@ -22,7 +22,7 @@ trait HasMedia
     public function media()
     {
         return $this->morphToMany(config('media.model'), 'mediable')
-                    ->withPivot('group');
+            ->withPivot('group');
     }
 
     /**
@@ -99,16 +99,14 @@ trait HasMedia
     {
         $ids = $this->parseMediaIds($media);
 
-        $media = [];
-        foreach ($ids as $id) {
-            $media[$id] = ['group' => $group];
-        }
-
-        \DB::transaction(function () use ($media, $group, $conversions, $detachExisting) {
+        \DB::transaction(function () use ($ids, $group, $conversions, $detachExisting) {
             $this->registerMediaGroups();
             $mediaGroup = $this->getMediaGroup($group);
 
-            $sync = $this->media()->sync($media, $detachExisting);
+            $sync = $this->media()->wherePivot('group', $group)
+                ->withPivotValue('group', $group)
+                ->sync($ids, $detachExisting);
+
             $ids = array_merge($sync['attached'], $sync['updated']);
 
             if ($mediaGroup && $mediaGroup->hasConversions()) {

--- a/src/HasMedia.php
+++ b/src/HasMedia.php
@@ -88,7 +88,7 @@ trait HasMedia
     }
 
     /**
-     * Syncronise media against the specified group
+     * Syncronise media against the specified group.
      *
      * @param mixed $media
      * @param string $group
@@ -118,7 +118,7 @@ trait HasMedia
                 );
             }
 
-            if (!empty($conversions) && count($ids)) {
+            if (! empty($conversions) && count($ids)) {
                 $model = config('media.model');
 
                 $media = $model::findMany($ids);

--- a/src/ImageManipulator.php
+++ b/src/ImageManipulator.php
@@ -55,7 +55,9 @@ class ImageManipulator
             $converter = $this->conversionRegistry->get($conversion);
 
             $image = $converter(
-                $this->imageManager->make($media->getFullPath())
+                $this->imageManager->make(
+                    $media->filesystem()->readStream($media->getPath())
+                )
             );
 
             $media->filesystem()->put($path, $image->stream());

--- a/tests/ImageManipulatorTest.php
+++ b/tests/ImageManipulatorTest.php
@@ -40,6 +40,7 @@ class ImageManipulatorTest extends TestCase
         $media->mime_type = 'image/png';
 
         $filesystem = Mockery::mock(Filesystem::class);
+        $filesystem->shouldReceive('readStream')->andReturn('stream-data');
         $filesystem->shouldReceive('path')->with($media->getPath())->andReturn('full-path');
 
         // Assert that the converted file is saved...


### PR DESCRIPTION
Hi,

I've updated the HasMedia trait to contain a `syncMedia` method which `attachMedia` relies on by default. This prevents under certain operations excessive duplicate relationships from being created.

Additionally, provides the user the ability to detach old relationships if they'd like to.